### PR TITLE
Upgrade `rubocop-betterment` to allow running tests on Ruby 2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   started:
     resource_class: small
     docker:
-    - image: 907128454492.dkr.ecr.us-east-1.amazonaws.com/betterment/coach-notifier/generic:1
+    - image: 907128454492.dkr.ecr.us-east-1.amazonaws.com/betterment/coach-notifier/generic:v1.x
     working_directory: "~/journaled"
     steps:
     - run:
@@ -17,7 +17,7 @@ jobs:
   completed:
     resource_class: small
     docker:
-    - image: 907128454492.dkr.ecr.us-east-1.amazonaws.com/betterment/coach-notifier/generic:1
+    - image: 907128454492.dkr.ecr.us-east-1.amazonaws.com/betterment/coach-notifier/generic:v1.x
     working_directory: "~/journaled"
     steps:
     - run:
@@ -32,7 +32,7 @@ jobs:
     environment:
       BUNDLE_GEMFILE: Gemfile
     docker:
-    - image: 907128454492.dkr.ecr.us-east-1.amazonaws.com/betterment/ruby/2.4.2:2
+    - image: 907128454492.dkr.ecr.us-east-1.amazonaws.com/betterment/ruby/2.6.1:v2.x
       environment:
         GEM_SOURCE: https://rubygems.org
         RAILS_ENV: test
@@ -54,9 +54,9 @@ jobs:
         key: v2-git-refs-{{ checksum "/tmp/.git-refs-cache-key" }}
     - restore_cache:
         keys:
-        - v0-journaled-2.4.2-Gemfile-{{ checksum "./coach.yml" }}-{{ checksum "./Gemfile"
+        - v0-journaled-2.6.1-Gemfile-{{ checksum "./coach.yml" }}-{{ checksum "./Gemfile"
           }}-{{ checksum "./journaled.gemspec" }}
-        - v0-journaled-2.4.2-Gemfile-
+        - v0-journaled-2.6.1-Gemfile-
     - run:
         name: bundle install dependencies
         command: |
@@ -66,7 +66,7 @@ jobs:
     - save_cache:
         paths:
         - "./vendor/bundle"
-        key: v0-journaled-2.4.2-Gemfile-{{ checksum "./coach.yml" }}-{{ checksum "./Gemfile"
+        key: v0-journaled-2.6.1-Gemfile-{{ checksum "./coach.yml" }}-{{ checksum "./Gemfile"
           }}-{{ checksum "./journaled.gemspec" }}
     - run:
         name: run rubocop
@@ -90,12 +90,12 @@ jobs:
       EAGER_LOAD: true
     parallelism: 1
     docker:
-    - image: 907128454492.dkr.ecr.us-east-1.amazonaws.com/betterment/ruby/2.4.2:2
+    - image: 907128454492.dkr.ecr.us-east-1.amazonaws.com/betterment/ruby/2.6.1:v2.x
       environment:
         GEM_SOURCE: https://rubygems.org
         RAILS_ENV: test
         RACK_ENV: test
-    - image: circleci/postgres:9.4
+    - image: circleci/postgres:9.6
       command: postgres --max_prepared_transactions=100
       environment:
         POSTGRES_USER: betterment
@@ -116,9 +116,9 @@ jobs:
         key: v2-git-refs-{{ checksum "/tmp/.git-refs-cache-key" }}
     - restore_cache:
         keys:
-        - v0-journaled-2.4.2-Gemfile-{{ checksum "./coach.yml" }}-{{ checksum "./Gemfile"
+        - v0-journaled-2.6.1-Gemfile-{{ checksum "./coach.yml" }}-{{ checksum "./Gemfile"
           }}-{{ checksum "./journaled.gemspec" }}
-        - v0-journaled-2.4.2-Gemfile-
+        - v0-journaled-2.6.1-Gemfile-
     - run:
         name: bundle install dependencies
         command: |
@@ -128,7 +128,7 @@ jobs:
     - save_cache:
         paths:
         - "./vendor/bundle"
-        key: v0-journaled-2.4.2-Gemfile-{{ checksum "./coach.yml" }}-{{ checksum "./Gemfile"
+        key: v0-journaled-2.6.1-Gemfile-{{ checksum "./coach.yml" }}-{{ checksum "./Gemfile"
           }}-{{ checksum "./journaled.gemspec" }}
     - run:
         name: wait for postgresql db
@@ -218,4 +218,4 @@ workflows:
             ignore: "/^deploy-attempts-.*/"
         requires:
         - started
-coach_version: 0.18.10
+coach_version: 0.19.4

--- a/app/controllers/concerns/journaled/actor.rb
+++ b/app/controllers/concerns/journaled/actor.rb
@@ -12,6 +12,7 @@ module Journaled::Actor
   class_methods do
     def journaled_actor=(method_name)
       raise "Must provide a symbol method name" unless method_name.is_a?(Symbol)
+
       self._journaled_actor_method_name = method_name
     end
   end

--- a/app/models/journaled/change_definition.rb
+++ b/app/models/journaled/change_definition.rb
@@ -19,6 +19,7 @@ class Journaled::ChangeDefinition
 
         #{nonexistent_attribute_names.join(', ')}
     ERROR
+
     @validated = true
   end
 end

--- a/coach.yml
+++ b/coach.yml
@@ -1,6 +1,6 @@
 project_type: ruby_gem
-ruby_version: 2.4.2
+ruby_version: 2.6.1
 resource_class: small
 databases:
-  postgresql:
-    version: 9.4
+  - type: postgresql
+    version: 9.6

--- a/journaled.gemspec
+++ b/journaled.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry-rails"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "rspec_junit_formatter"
-  s.add_development_dependency "rubocop-betterment", "1.3.0"
+  s.add_development_dependency "rubocop-betterment", "1.8.0"
   s.add_development_dependency "timecop"
   s.add_development_dependency "webmock"
 end

--- a/spec/dummy/app/models/soldier.rb
+++ b/spec/dummy/app/models/soldier.rb
@@ -1,0 +1,2 @@
+class Soldier < ActiveRecord::Base
+end

--- a/spec/dummy/db/migrate/20190529213045_add_soldier_table.rb
+++ b/spec/dummy/db/migrate/20190529213045_add_soldier_table.rb
@@ -1,0 +1,10 @@
+class AddSoldierTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :soldiers do |t|
+      t.string :name
+      t.string :rank
+      t.string :serial_number
+      t.datetime :last_sign_in_at
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180606205114) do
+ActiveRecord::Schema.define(version: 2019_05_29_213045) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,4 +29,12 @@ ActiveRecord::Schema.define(version: 20180606205114) do
     t.datetime "updated_at"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
+
+  create_table "soldiers", force: :cascade do |t|
+    t.string "name"
+    t.string "rank"
+    t.string "serial_number"
+    t.datetime "last_sign_in_at"
+  end
+
 end

--- a/spec/lib/journaled_spec.rb
+++ b/spec/lib/journaled_spec.rb
@@ -43,8 +43,9 @@ RSpec.describe Journaled do
   end
 
   describe "#actor_uri" do
+    let(:uri_provider_double) { instance_double(Journaled::ActorUriProvider, actor_uri: "my actor uri") }
     it "delegates to ActorUriProvider" do
-      allow(Journaled::ActorUriProvider).to receive(:instance).and_return(double(actor_uri: "my actor uri"))
+      allow(Journaled::ActorUriProvider).to receive(:instance).and_return(uri_provider_double)
       expect(described_class.actor_uri).to eq "my actor uri"
     end
   end

--- a/spec/lib/journaled_spec.rb
+++ b/spec/lib/journaled_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Journaled do
 
   describe "#actor_uri" do
     let(:uri_provider_double) { instance_double(Journaled::ActorUriProvider, actor_uri: "my actor uri") }
+
     it "delegates to ActorUriProvider" do
       allow(Journaled::ActorUriProvider).to receive(:instance).and_return(uri_provider_double)
       expect(described_class.actor_uri).to eq "my actor uri"

--- a/spec/lib/journaled_spec.rb
+++ b/spec/lib/journaled_spec.rb
@@ -3,49 +3,49 @@ require 'rails_helper'
 RSpec.describe Journaled do
   it "is enabled in production" do
     allow(Rails).to receive(:env).and_return("production")
-    expect(Journaled).to be_enabled
+    expect(described_class).to be_enabled
   end
 
   it "is disabled in development" do
     allow(Rails).to receive(:env).and_return("development")
-    expect(Journaled).not_to be_enabled
+    expect(described_class).not_to be_enabled
   end
 
   it "is disabled in test" do
     allow(Rails).to receive(:env).and_return("test")
-    expect(Journaled).not_to be_enabled
+    expect(described_class).not_to be_enabled
   end
 
   it "is enabled in whatevs" do
     allow(Rails).to receive(:env).and_return("whatevs")
-    expect(Journaled).to be_enabled
+    expect(described_class).to be_enabled
   end
 
   it "is enabled when explicitly enabled in development" do
     with_env(JOURNALED_ENABLED: true) do
       allow(Rails).to receive(:env).and_return("development")
-      expect(Journaled).to be_enabled
+      expect(described_class).to be_enabled
     end
   end
 
   it "is disabled when explicitly disabled in production" do
     with_env(JOURNALED_ENABLED: false) do
       allow(Rails).to receive(:env).and_return("production")
-      expect(Journaled).not_to be_enabled
+      expect(described_class).not_to be_enabled
     end
   end
 
   it "is disabled when explicitly disabled with empty string" do
     with_env(JOURNALED_ENABLED: '') do
       allow(Rails).to receive(:env).and_return("production")
-      expect(Journaled).not_to be_enabled
+      expect(described_class).not_to be_enabled
     end
   end
 
   describe "#actor_uri" do
     it "delegates to ActorUriProvider" do
       allow(Journaled::ActorUriProvider).to receive(:instance).and_return(double(actor_uri: "my actor uri"))
-      expect(Journaled.actor_uri).to eq "my actor uri"
+      expect(described_class.actor_uri).to eq "my actor uri"
     end
   end
 end

--- a/spec/models/concerns/journaled/actor_spec.rb
+++ b/spec/models/concerns/journaled/actor_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 # This is a controller mixin, but testing as a model spec!
 RSpec.describe Journaled::Actor do
-  let(:user) { double("User") }
+  let(:user) { double }
   let(:klass) do
     Class.new do
       cattr_accessor :before_actions

--- a/spec/models/concerns/journaled/actor_spec.rb
+++ b/spec/models/concerns/journaled/actor_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Journaled::Actor do
   it "Stores a thunk returning nil if current_user returns nil" do
     subject.trigger_before_actions
 
-    allow(subject).to receive(:current_user).and_return(nil)
+    allow(subject).to receive(:current_user).and_return(nil) # rubocop:disable RSpec/SubjectStub
 
     expect(RequestStore.store[:journaled_actor_proc].call).to eq nil
   end
@@ -39,7 +39,7 @@ RSpec.describe Journaled::Actor do
   it "Stores a thunk returning current_user if it is set when called" do
     subject.trigger_before_actions
 
-    allow(subject).to receive(:current_user).and_return(user)
+    allow(subject).to receive(:current_user).and_return(user) # rubocop:disable RSpec/SubjectStub
 
     expect(RequestStore.store[:journaled_actor_proc].call).to eq user
   end

--- a/spec/models/concerns/journaled/changes_spec.rb
+++ b/spec/models/concerns/journaled/changes_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Journaled::Changes do
 
   subject { klass.new }
 
-  let(:change_writer) { double(Journaled::ChangeWriter, create: true, update: true, delete: true) }
+  let(:change_writer) { instance_double(Journaled::ChangeWriter, create: true, update: true, delete: true) }
 
   before do
     allow(Journaled::ChangeWriter).to receive(:new) do |opts|

--- a/spec/models/concerns/journaled/changes_spec.rb
+++ b/spec/models/concerns/journaled/changes_spec.rb
@@ -47,11 +47,13 @@ RSpec.describe Journaled::Changes do
   let(:change_writer) { instance_double(Journaled::ChangeWriter, create: true, update: true, delete: true) }
 
   before do
+    # rubocop:disable RSpec/ExpectInHook
     allow(Journaled::ChangeWriter).to receive(:new) do |opts|
       expect(opts[:model]).to eq(subject)
       expect(opts[:change_definition].logical_operation).to eq(:change_of_heart)
       change_writer
     end
+    # rubocop:enable RSpec/ExpectInHook
   end
 
   it "can be asserted on with our matcher" do

--- a/spec/models/concerns/journaled/changes_spec.rb
+++ b/spec/models/concerns/journaled/changes_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Journaled::Changes do
       def self.after_save(opts, &hook)
         # This is a back-door assertion to prevent regressions in the module's hook definition behavior
         raise "expected `unless: :saved_change_to_id?`" unless opts[:unless] == :saved_change_to_id?
+
         after_save_hooks << hook
       end
 

--- a/spec/models/journaled/actor_uri_provider_spec.rb
+++ b/spec/models/journaled/actor_uri_provider_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Journaled::ActorUriProvider do
   describe "#actor_uri" do
-    let(:request_store) { double(:[] => nil) }
-    let(:actor) { double(to_global_id: actor_gid) }
-    let(:actor_gid) { double(to_s: "my_fancy_gid") }
+    let(:request_store) { class_double(RequestStore, :[] => nil) }
+    let(:actor) { instance_double(ActiveRecord::Base, to_global_id: actor_gid) }
+    let(:actor_gid) { instance_double(GlobalID, to_s: "my_fancy_gid") }
     let(:program_name) { "/usr/local/bin/puma_or_something" }
 
     subject { described_class.instance }

--- a/spec/models/journaled/change_writer_spec.rb
+++ b/spec/models/journaled/change_writer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Journaled::ChangeWriter do
   let(:model) do
     now = Time.zone.now
     instance_double(
-      ActiveRecord::Base,
+      model_class,
       id: 28_473,
       class: model_class,
       attributes: {
@@ -19,14 +19,7 @@ RSpec.describe Journaled::ChangeWriter do
       }
     )
   end
-
-  let(:model_class) do
-    class_double(
-      'Soldier',
-      table_name: "soldiers",
-      attribute_names: %w(id name rank serial_number last_sign_in_at)
-    )
-  end
+  let(:model_class) { Soldier }
 
   let(:change_definition) do
     Journaled::ChangeDefinition.new(
@@ -51,7 +44,7 @@ RSpec.describe Journaled::ChangeWriter do
   describe "#relevant_attributes" do
     let(:model) do
       instance_double(
-        ActiveRecord::Base,
+        model_class,
          id: 28_473,
          class: model_class,
          attributes: {
@@ -76,7 +69,7 @@ RSpec.describe Journaled::ChangeWriter do
   describe "#relevant_unperturbed_attributes" do
     let(:model) do
       instance_double(
-        ActiveRecord::Base,
+        model_class,
          id: 28_473,
          class: model_class,
          attributes: {
@@ -155,8 +148,16 @@ RSpec.describe Journaled::ChangeWriter do
     end
 
     context "when model class defines journaled_app_name" do
-      before do
-        allow(model_class).to receive(:journaled_app_name).and_return("my_app")
+      let(:model_class) do
+        Class.new(ActiveRecord::Base) do
+          def self.table_name
+            'soldiers'
+          end
+
+          def self.journaled_app_name
+            "my_app"
+          end
+        end
       end
 
       it "sets journaled_app_name if model_class responds to it" do
@@ -175,7 +176,7 @@ RSpec.describe Journaled::ChangeWriter do
     describe "#create" do
       let(:model) do
         instance_double(
-          ActiveRecord::Base,
+          model_class,
            id: 28_473,
            class: model_class,
            attributes: {
@@ -217,7 +218,7 @@ RSpec.describe Journaled::ChangeWriter do
       context "with no changes" do
         let(:model) do
           instance_double(
-            ActiveRecord::Base,
+            model_class,
              id: 28_473,
              class: model_class,
              attributes: {
@@ -243,7 +244,7 @@ RSpec.describe Journaled::ChangeWriter do
       let(:model) do
         now = Time.zone.now
         instance_double(
-          ActiveRecord::Base,
+          model_class,
            id: 28_473,
            class: model_class,
            attributes: {

--- a/spec/models/journaled/change_writer_spec.rb
+++ b/spec/models/journaled/change_writer_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe Journaled::ChangeWriter do
   let(:model) do
     now = Time.zone.now
-    double(
-      "Soldier",
+    instance_double(
+      ActiveRecord::Base,
       id: 28_473,
       class: model_class,
       attributes: {
@@ -21,8 +21,8 @@ RSpec.describe Journaled::ChangeWriter do
   end
 
   let(:model_class) do
-    double(
-      "SoldierClass",
+    class_double(
+      'Soldier',
       table_name: "soldiers",
       attribute_names: %w(id name rank serial_number last_sign_in_at)
     )
@@ -50,18 +50,18 @@ RSpec.describe Journaled::ChangeWriter do
 
   describe "#relevant_attributes" do
     let(:model) do
-      double(
-        "Soldier",
-        id: 28_473,
-        class: model_class,
-        attributes: {
-          "name" => "bill",
-          "rank" => "first lieutenant",
-          "serial_number" => "foobar",
-          "last_sign_in_at" => Time.zone.now
-        },
-        saved_changes: {}
-      )
+      instance_double(
+        ActiveRecord::Base,
+         id: 28_473,
+         class: model_class,
+         attributes: {
+           "name" => "bill",
+           "rank" => "first lieutenant",
+           "serial_number" => "foobar",
+           "last_sign_in_at" => Time.zone.now
+         },
+         saved_changes: {}
+       )
     end
 
     it "returns all relevant attributes regardless of saved changes" do
@@ -75,20 +75,20 @@ RSpec.describe Journaled::ChangeWriter do
 
   describe "#relevant_unperturbed_attributes" do
     let(:model) do
-      double(
-        "Soldier",
-        id: 28_473,
-        class: model_class,
-        attributes: {
-          "name" => "bill",
-          "rank" => "first lieutenant",
-          "serial_number" => "foobar",
-          "last_sign_in_at" => Time.zone.now
-        },
-        changes: {
-          "name" => %w(bob bill)
-        }
-      )
+      instance_double(
+        ActiveRecord::Base,
+         id: 28_473,
+         class: model_class,
+         attributes: {
+           "name" => "bill",
+           "rank" => "first lieutenant",
+           "serial_number" => "foobar",
+           "last_sign_in_at" => Time.zone.now
+         },
+         changes: {
+           "name" => %w(bob bill)
+         }
+       )
     end
 
     it "returns the pre-change value of the attributes, regardless of whether they changed" do
@@ -107,8 +107,10 @@ RSpec.describe Journaled::ChangeWriter do
   end
 
   describe "#actor_uri" do
+    let(:uri_provider_double) { instance_double(Journaled::ActorUriProvider, actor_uri: "my actor uri") }
+
     it "delegates to ActorUriProvider" do
-      allow(Journaled::ActorUriProvider).to receive(:instance).and_return(double(actor_uri: "my actor uri"))
+      allow(Journaled::ActorUriProvider).to receive(:instance).and_return(uri_provider_double)
       expect(Journaled.actor_uri).to eq "my actor uri"
     end
   end
@@ -172,18 +174,18 @@ RSpec.describe Journaled::ChangeWriter do
 
     describe "#create" do
       let(:model) do
-        double(
-          "Soldier",
-          id: 28_473,
-          class: model_class,
-          attributes: {
-            "name" => "bill",
-            "rank" => "first lieutenant",
-            "serial_number" => "foobar",
-            "last_sign_in_at" => Time.zone.now
-          },
-          saved_changes: {}
-        )
+        instance_double(
+          ActiveRecord::Base,
+           id: 28_473,
+           class: model_class,
+           attributes: {
+             "name" => "bill",
+             "rank" => "first lieutenant",
+             "serial_number" => "foobar",
+             "last_sign_in_at" => Time.zone.now
+           },
+           saved_changes: {}
+         )
       end
 
       it "always journals all relevant attributes, even if unchanged" do
@@ -214,18 +216,18 @@ RSpec.describe Journaled::ChangeWriter do
 
       context "with no changes" do
         let(:model) do
-          double(
-            "Soldier",
-            id: 28_473,
-            class: model_class,
-            attributes: {
-              "name" => "bill",
-              "rank" => "first lieutenant",
-              "serial_number" => "foobar",
-              "last_sign_in_at" => Time.zone.now
-            },
-            saved_changes: {}
-          )
+          instance_double(
+            ActiveRecord::Base,
+             id: 28_473,
+             class: model_class,
+             attributes: {
+               "name" => "bill",
+               "rank" => "first lieutenant",
+               "serial_number" => "foobar",
+               "last_sign_in_at" => Time.zone.now
+             },
+             saved_changes: {}
+           )
         end
 
         it "doesn't journal" do
@@ -240,20 +242,20 @@ RSpec.describe Journaled::ChangeWriter do
     describe "#delete" do
       let(:model) do
         now = Time.zone.now
-        double(
-          "Soldier",
-          id: 28_473,
-          class: model_class,
-          attributes: {
-            "name" => "bob",
-            "rank" => "first lieutenant",
-            "serial_number" => "foobar",
-            "last_sign_in_at" => now
-          },
-          changes: {
-            "name" => %w(bill bob)
-          }
-        )
+        instance_double(
+          ActiveRecord::Base,
+           id: 28_473,
+           class: model_class,
+           attributes: {
+             "name" => "bob",
+             "rank" => "first lieutenant",
+             "serial_number" => "foobar",
+             "last_sign_in_at" => now
+           },
+           changes: {
+             "name" => %w(bill bob)
+           }
+         )
       end
 
       it "journals the unperturbed values of all relevant attributes" do

--- a/spec/models/journaled/writer_spec.rb
+++ b/spec/models/journaled/writer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Journaled::Writer do
 
   describe '#initialize' do
     context 'when the Journaled Event does not implement all the necessary methods' do
-      let(:journaled_event) { double }
+      let(:journaled_event) { instance_double Journaled::Event }
 
       it 'raises on initialization' do
         expect { subject }.to raise_error RuntimeError, /An enqueued event must respond to/
@@ -14,12 +14,11 @@ RSpec.describe Journaled::Writer do
 
     context 'when the Journaled Event returns non-present values for some of the required methods' do
       let(:journaled_event) do
-        double(
-          journaled_schema_name: nil,
-          journaled_attributes: {},
-          journaled_partition_key: '',
-          journaled_app_name: nil
-        )
+        instance_double(Journaled::Event,
+           journaled_schema_name: nil,
+           journaled_attributes: {},
+           journaled_partition_key: '',
+           journaled_app_name: nil)
       end
 
       it 'raises on initialization' do
@@ -29,12 +28,11 @@ RSpec.describe Journaled::Writer do
 
     context 'when the Journaled Event complies with the API' do
       let(:journaled_event) do
-        double(
-          journaled_schema_name: :fake_schema_name,
-          journaled_attributes: { foo: :bar },
-          journaled_partition_key: 'fake_partition_key',
-          journaled_app_name: nil
-        )
+        instance_double(Journaled::Event,
+           journaled_schema_name: :fake_schema_name,
+           journaled_attributes: { foo: :bar },
+           journaled_partition_key: 'fake_partition_key',
+           journaled_app_name: nil)
       end
 
       it 'does not raise on initialization' do
@@ -68,12 +66,11 @@ RSpec.describe Journaled::Writer do
     end
 
     let(:journaled_event) do
-      double(
-        journaled_schema_name: :fake_schema_name,
-        journaled_attributes: journaled_event_attributes,
-        journaled_partition_key: 'fake_partition_key',
-        journaled_app_name: 'my_app'
-      )
+      instance_double(Journaled::Event,
+         journaled_schema_name: :fake_schema_name,
+         journaled_attributes: journaled_event_attributes,
+         journaled_partition_key: 'fake_partition_key',
+         journaled_app_name: 'my_app')
     end
 
     around do |example|

--- a/spec/models/journaled/writer_spec.rb
+++ b/spec/models/journaled/writer_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Journaled::Writer do
       end
 
       it 'does not raise on initialization' do
-        expect { subject }.to_not raise_error
+        expect { subject }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
### Summary

This PR updates the version of `rubocop-betterment` to the latest version. The version that we were pinned to before did NOT support Ruby 2.6, which is what I had installed locally.

I decided to take this opportunity to get us on the latest `rubocop-betterment` which DOES support Ruby 2.6.
Most of this PR is fixing the violations that cropped up when upgrading `rubocop`

Since this was in service of getting Ruby 2.6 tests running, I updated the Coach Config file such that we are now running CI against Ruby 2.6

/domain @Betterment/journaled-owners
/no-platform
