### PR TITLE
Adds assume role functionality for kinesis client constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ app's Gemfile.
     `AWS_DEFAULT_REGION`. If you don't specify, Journaled will default to
     `us-east-1`.
 
+    You may also specify a role that the Kinesis AWS client can assume:
+
+      * `JOURNALED_IAM_ROLE_NAME`
+
+    The actor whose credentials are in the environment will need to be allowed to assume this role.
+
 ## Usage
 
 ### Change Journaling

--- a/app/models/journaled/delivery.rb
+++ b/app/models/journaled/delivery.rb
@@ -12,7 +12,7 @@ class Journaled::Delivery
   rescue Aws::Kinesis::Errors::InternalFailure, Aws::Kinesis::Errors::ServiceUnavailable, Aws::Kinesis::Errors::Http503Error => e
     Rails.logger.error "Kinesis Error - Server Error occurred - #{e.class}"
     raise KinesisTemporaryFailure
-  rescue Aws::Kinesis::Errors::SeahorseClientNetworkingError => e
+  rescue Seahorse::Client::NetworkingError => e
     Rails.logger.error "Kinesis Error - Networking Error occurred - #{e.class}"
     raise KinesisTemporaryFailure
   end

--- a/app/models/journaled/delivery.rb
+++ b/app/models/journaled/delivery.rb
@@ -26,7 +26,7 @@ class Journaled::Delivery
     {
       region: ENV.fetch('AWS_DEFAULT_REGION', DEFAULT_REGION),
       retry_limit: 0
-    }.merge(legacy_credentials_hash)
+    }.merge(legacy_credentials_hash_if_present)
   end
 
   private
@@ -49,7 +49,7 @@ class Journaled::Delivery
     end
   end
 
-  def legacy_credentials_hash
+  def legacy_credentials_hash_if_present
     if ENV.key?('RUBY_AWS_ACCESS_KEY_ID')
       {
         access_key_id: ENV.fetch('RUBY_AWS_ACCESS_KEY_ID'),
@@ -62,7 +62,7 @@ class Journaled::Delivery
 
   def iam_assume_role_credentials
     @iam_assume_role_credentials ||= Aws::AssumeRoleCredentials.new(
-      client: Aws::STS::Client.new(legacy_credentials_hash),
+      client: Aws::STS::Client.new(legacy_credentials_hash_if_present),
       role_arn: ENV.fetch('JOURNALED_IAM_ROLE_NAME'),
       role_session_name: "JournaledAssumeRoleAccess"
     )

--- a/lib/journaled/version.rb
+++ b/lib/journaled/version.rb
@@ -1,3 +1,3 @@
 module Journaled
-  VERSION = "2.0.0".freeze
+  VERSION = "2.0.1".freeze
 end

--- a/spec/models/journaled/delivery_spec.rb
+++ b/spec/models/journaled/delivery_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Journaled::Delivery do
   let(:stream_name) { 'test_events' }
   let(:partition_key) { 'fake_partition_key' }
   let(:serialized_event) { '{"foo":"bar"}' }
-  let(:aws_sts_client) { Aws::STS::Client.new(stub_responses: true) }
   let(:kinesis_client) { Aws::Kinesis::Client.new(stub_responses: true) }
 
   around do |example|
@@ -33,6 +32,8 @@ RSpec.describe Journaled::Delivery do
     end
 
     context 'when JOURNALED_IAM_ROLE_NAME is defined' do
+      let(:aws_sts_client) { Aws::STS::Client.new(stub_responses: true) }
+
       around do |example|
         with_env(JOURNALED_IAM_ROLE_NAME: 'iam-role-arn-for-assuming-kinesis-access') { example.run }
       end

--- a/spec/models/journaled/delivery_spec.rb
+++ b/spec/models/journaled/delivery_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Journaled::Delivery do
   let(:stream_name) { 'test_events' }
   let(:partition_key) { 'fake_partition_key' }
   let(:serialized_event) { '{"foo":"bar"}' }
+  let(:aws_sts_client) { Aws::STS::Client.new(stub_responses: true) }
+  let(:kinesis_client) { Aws::Kinesis::Client.new(stub_responses: true) }
 
   around do |example|
     with_env(JOURNALED_STREAM_NAME: stream_name) { example.run }
@@ -12,29 +14,58 @@ RSpec.describe Journaled::Delivery do
   subject { described_class.new serialized_event: serialized_event, partition_key: partition_key, app_name: nil }
 
   describe '#perform' do
-    let!(:stubbed_request) do
-      stub_request(:post, 'https://kinesis.us-east-1.amazonaws.com').to_return(status: return_status_code, body: return_status_body)
-    end
-    let(:return_status_code) { 200 }
-    let(:return_status_body) { return_status_body_hash.to_json }
-    let(:return_status_body_hash) { { RecordId: '101' } }
-
-    let(:stubbed_body) do
-      {
-        'StreamName' => stream_name,
-        'Data' => Base64.encode64(serialized_event).strip,
-        'PartitionKey' => 'fake_partition_key'
-      }
-    end
+    let(:return_status_body) { { shard_id: '101', sequence_number: '101123' } }
+    let(:return_object) { instance_double Aws::Kinesis::Types::PutRecordOutput, return_status_body }
 
     before do
+      allow(Aws::AssumeRoleCredentials).to receive(:new).and_call_original
+      allow(Aws::Kinesis::Client).to receive(:new).and_return kinesis_client
+      kinesis_client.stub_responses(:put_record, return_status_body)
+
       allow(Journaled).to receive(:enabled?).and_return(true)
     end
 
     it 'makes requests to AWS to put the event on the Kinesis with the correct body' do
-      subject.perform
+      event = subject.perform
 
-      expect(stubbed_request.with(body: stubbed_body.to_json)).to have_been_requested.once
+      expect(event.shard_id).to eq '101'
+      expect(event.sequence_number).to eq '101123'
+    end
+
+    context 'when JOURNALED_IAM_ROLE_NAME is defined' do
+      around do |example|
+        with_env(JOURNALED_IAM_ROLE_NAME: 'iam-role-arn-for-assuming-kinesis-access') { example.run }
+      end
+
+      before do
+        allow(Aws::STS::Client).to receive(:new).and_return aws_sts_client
+        aws_sts_client.stub_responses(:assume_role, assume_role_response)
+      end
+
+      let(:assume_role_response) do
+        {
+          assumed_role_user: {
+            arn: 'iam-role-arn-for-assuming-kinesis-access',
+            assumed_role_id: "ARO123EXAMPLE123:Bob"
+          },
+          credentials: {
+            access_key_id: "AKIAIOSFODNN7EXAMPLE",
+            secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY",
+            session_token: "EXAMPLEtc764bNrC9SAPBSM22wDOk4x4HIZ8j4FZTwdQWLWsKWHGBuFqwAeMicRXmxfpSPfIeoIYRqTflfKD8YUuwthAx7mSEI",
+            expiration: Time.zone.parse("2011-07-15T23:28:33.359Z")
+          }
+        }
+      end
+
+      it 'initializes a Kinesis client with assume role credentials' do
+        subject.perform
+
+        expect(Aws::AssumeRoleCredentials).to have_received(:new).with(
+          client: aws_sts_client,
+          role_arn: "iam-role-arn-for-assuming-kinesis-access",
+          role_session_name: "JournaledAssumeRoleAccess"
+        )
+      end
     end
 
     context 'when the stream name env var is NOT set' do
@@ -46,57 +77,58 @@ RSpec.describe Journaled::Delivery do
     end
 
     context 'when Amazon responds with an InternalFailure' do
-      let(:return_status_code) { 500 }
-      let(:return_status_body_hash) { { __type: 'InternalFailure' } }
+      before do
+        kinesis_client.stub_responses(:put_record, 'InternalFailure')
+      end
 
       it 'catches the error and re-raises a subclass of NotTrulyExceptionalError and logs about the failure' do
         expect(Rails.logger).to receive(:error).with("Kinesis Error - Server Error occurred - Aws::Kinesis::Errors::InternalFailure").once
         expect { subject.perform }.to raise_error described_class::KinesisTemporaryFailure
-        expect(stubbed_request).to have_been_requested.once
       end
     end
 
     context 'when Amazon responds with a ServiceUnavailable' do
-      let(:return_status_code) { 503 }
-      let(:return_status_body_hash) { { __type: 'ServiceUnavailable' } }
+      before do
+        kinesis_client.stub_responses(:put_record, 'ServiceUnavailable')
+      end
 
       it 'catches the error and re-raises a subclass of NotTrulyExceptionalError and logs about the failure' do
         allow(Rails.logger).to receive(:error)
         expect { subject.perform }.to raise_error described_class::KinesisTemporaryFailure
-        expect(stubbed_request).to have_been_requested.once
         expect(Rails.logger).to have_received(:error).with(/\AKinesis Error/).once
       end
     end
 
     context 'when we receive a 504 Gateway timeout' do
-      let(:return_status_code) { 504 }
-      let(:return_status_body) { nil }
+      before do
+        kinesis_client.stub_responses(:put_record, 'Aws::Kinesis::Errors::ServiceError')
+      end
 
       it 'raises an error that subclasses Aws::Kinesis::Errors::ServiceError' do
         expect { subject.perform }.to raise_error Aws::Kinesis::Errors::ServiceError
-        expect(stubbed_request).to have_been_requested.once
       end
     end
 
     context 'when the IAM user does not have permission to put_record to the specified stream' do
-      let(:return_status_code) { 400 }
-      let(:return_status_body_hash) { { __type: 'AccessDeniedException' } }
+      before do
+        kinesis_client.stub_responses(:put_record, 'AccessDeniedException')
+      end
 
       it 'raises an AccessDeniedException error' do
         expect { subject.perform }.to raise_error Aws::Kinesis::Errors::AccessDeniedException
-        expect(stubbed_request).to have_been_requested.once
       end
     end
 
     context 'when the request timesout' do
-      let!(:stubbed_request) do
-        stub_request(:post, 'https://kinesis.us-east-1.amazonaws.com').to_timeout
+      before do
+        kinesis_client.stub_responses(:put_record, 'Seahorse::Client::NetworkingError')
       end
 
       it 'catches the error and re-raises a subclass of NotTrulyExceptionalError and logs about the failure' do
-        expect(Rails.logger).to receive(:error).with("Kinesis Error - Networking Error occurred - Seahorse::Client::NetworkingError").once
+        expect(Rails.logger).to receive(:error).with(
+          "Kinesis Error - Networking Error occurred - Aws::Kinesis::Errors::SeahorseClientNetworkingError"
+        ).once
         expect { subject.perform }.to raise_error described_class::KinesisTemporaryFailure
-        expect(stubbed_request).to have_been_requested.once
       end
     end
   end

--- a/spec/models/journaled/delivery_spec.rb
+++ b/spec/models/journaled/delivery_spec.rb
@@ -121,12 +121,12 @@ RSpec.describe Journaled::Delivery do
 
     context 'when the request timesout' do
       before do
-        kinesis_client.stub_responses(:put_record, 'Seahorse::Client::NetworkingError')
+        kinesis_client.stub_responses(:put_record, Seahorse::Client::NetworkingError.new(Timeout::Error.new))
       end
 
       it 'catches the error and re-raises a subclass of NotTrulyExceptionalError and logs about the failure' do
         expect(Rails.logger).to receive(:error).with(
-          "Kinesis Error - Networking Error occurred - Aws::Kinesis::Errors::SeahorseClientNetworkingError"
+          "Kinesis Error - Networking Error occurred - Seahorse::Client::NetworkingError"
         ).once
         expect { subject.perform }.to raise_error described_class::KinesisTemporaryFailure
       end


### PR DESCRIPTION
This feature allows the Kinesis client to be configured with credentials via assume-role instead of expecting credentials that belong to an IAM user with the right set of permissions. This is a best practice in that it supports the idea that permissions should be restricted in the most granular way possible. It follows the pattern established in the AWS docs [here](https://docs.aws.amazon.com/sdkforruby/api/Aws/AssumeRoleCredentials.html).

I also made a change in the Delivery spec code to use the AWS recommended way of stubbing responses on an AWS client. 

<!-- Please leave the below code review requests in place -->
/domain @Betterment/journaled-owners
/platform @jmileham @coreyja @ceslami @danf1024

cc @Betterment/squad-sre 
