### PR TITLE
Rename environment variable and update the sts client config to include AWS Region

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ app's Gemfile.
 
     You may also specify a role that the Kinesis AWS client can assume:
 
-      * `JOURNALED_IAM_ROLE_NAME`
+      * `JOURNALED_IAM_ROLE_ARN`
 
     The AWS principal whose credentials are in the environment will need to be allowed to assume this role.
 

--- a/app/models/journaled/delivery.rb
+++ b/app/models/journaled/delivery.rb
@@ -26,7 +26,7 @@ class Journaled::Delivery
     {
       region: ENV.fetch('AWS_DEFAULT_REGION', DEFAULT_REGION),
       retry_limit: 0
-    }.merge(legacy_credentials_hash_if_present)
+    }.merge(credentials)
   end
 
   private
@@ -42,10 +42,16 @@ class Journaled::Delivery
   end
 
   def kinesis_client
-    if ENV.key?('JOURNALED_IAM_ROLE_NAME')
-      Aws::Kinesis::Client.new(credentials: iam_assume_role_credentials)
+    Aws::Kinesis::Client.new(kinesis_client_config)
+  end
+
+  def credentials
+    if ENV.key?('JOURNALED_IAM_ROLE_ARN')
+      {
+        credentials: iam_assume_role_credentials
+      }
     else
-      Aws::Kinesis::Client.new(kinesis_client_config)
+      legacy_credentials_hash_if_present
     end
   end
 
@@ -60,10 +66,16 @@ class Journaled::Delivery
     end
   end
 
+  def sts_client
+    Aws::STS::Client.new({
+      region: ENV.fetch('AWS_DEFAULT_REGION', DEFAULT_REGION)
+    }.merge(legacy_credentials_hash_if_present))
+  end
+
   def iam_assume_role_credentials
     @iam_assume_role_credentials ||= Aws::AssumeRoleCredentials.new(
-      client: Aws::STS::Client.new(legacy_credentials_hash_if_present),
-      role_arn: ENV.fetch('JOURNALED_IAM_ROLE_NAME'),
+      client: sts_client,
+      role_arn: ENV.fetch('JOURNALED_IAM_ROLE_ARN'),
       role_session_name: "JournaledAssumeRoleAccess"
     )
   end

--- a/lib/journaled/version.rb
+++ b/lib/journaled/version.rb
@@ -1,3 +1,3 @@
 module Journaled
-  VERSION = "2.0.1".freeze
+  VERSION = "2.0.2".freeze
 end

--- a/spec/models/journaled/delivery_spec.rb
+++ b/spec/models/journaled/delivery_spec.rb
@@ -31,11 +31,11 @@ RSpec.describe Journaled::Delivery do
       expect(event.sequence_number).to eq '101123'
     end
 
-    context 'when JOURNALED_IAM_ROLE_NAME is defined' do
+    context 'when JOURNALED_IAM_ROLE_ARN is defined' do
       let(:aws_sts_client) { Aws::STS::Client.new(stub_responses: true) }
 
       around do |example|
-        with_env(JOURNALED_IAM_ROLE_NAME: 'iam-role-arn-for-assuming-kinesis-access') { example.run }
+        with_env(JOURNALED_IAM_ROLE_ARN: 'iam-role-arn-for-assuming-kinesis-access') { example.run }
       end
 
       before do


### PR DESCRIPTION
This clarifies the assume role configuration setup by renaming the environment variable (the complete ARN is required) and resolves a problem with the STS client configuration by including the AWS region.

<!-- Please leave the below code review requests in place -->
/domain @Betterment/journaled-owners
/platform @jmileham @coreyja @ceslami @danf1024
