### PR TITLE
adds support for string updates on relations

### DIFF
--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    journaled (2.0.2)
+    journaled (2.1.0)
       aws-sdk-resources (< 4)
       delayed_job
       json-schema
@@ -916,6 +916,10 @@ GEM
       rubocop (= 0.56)
     ruby-progressbar (1.10.1)
     safe_yaml (1.0.5)
+    spring (2.0.2)
+      activesupport (>= 4.2)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -949,8 +953,10 @@ DEPENDENCIES
   rspec-rails
   rspec_junit_formatter
   rubocop-betterment (= 1.3.0)
+  spring
+  spring-commands-rspec
   timecop
   webmock
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/lib/journaled/relation_change_protection.rb
+++ b/lib/journaled/relation_change_protection.rb
@@ -1,5 +1,5 @@
 module Journaled::RelationChangeProtection
-  def update_all(updates, force: false)
+  def update_all(updates, force: false) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
     unless force || !@klass.respond_to?(:journaled_attribute_names) || @klass.journaled_attribute_names.empty?
       conflicting_journaled_attribute_names = if updates.is_a?(Hash)
                                                 @klass.journaled_attribute_names & updates.keys.map(&:to_sym)

--- a/lib/journaled/relation_change_protection.rb
+++ b/lib/journaled/relation_change_protection.rb
@@ -1,7 +1,15 @@
 module Journaled::RelationChangeProtection
   def update_all(updates, force: false)
     unless force || !@klass.respond_to?(:journaled_attribute_names) || @klass.journaled_attribute_names.empty?
-      conflicting_journaled_attribute_names = @klass.journaled_attribute_names & updates.keys.map(&:to_sym)
+      conflicting_journaled_attribute_names = if updates.is_a?(Hash)
+                                                @klass.journaled_attribute_names & updates.keys.map(&:to_sym)
+                                              elsif updates.is_a?(String)
+                                                @klass.journaled_attribute_names.select do |a|
+                                                  updates.match?(/(^|\A|[ \.\\\"])#{a}[\z \\\"]/)
+                                                end
+                                              else
+                                                raise "unsupported type '#{updates.class}' for 'updates'"
+                                              end
       raise(<<~ERROR) if conflicting_journaled_attribute_names.present?
         .update_all aborted by Journaled::Changes due to journaled attributes:
 

--- a/lib/journaled/relation_change_protection.rb
+++ b/lib/journaled/relation_change_protection.rb
@@ -5,7 +5,7 @@ module Journaled::RelationChangeProtection
                                                 @klass.journaled_attribute_names & updates.keys.map(&:to_sym)
                                               elsif updates.is_a?(String)
                                                 @klass.journaled_attribute_names.select do |a|
-                                                  updates.match?(/(^|\A|[ \.\\\"])#{a}[\z \\\"]/)
+                                                  updates.match?(/(^|\A|[ \.\"])#{a}[\z \"$]/)
                                                 end
                                               else
                                                 raise "unsupported type '#{updates.class}' for 'updates'"

--- a/lib/journaled/relation_change_protection.rb
+++ b/lib/journaled/relation_change_protection.rb
@@ -5,7 +5,7 @@ module Journaled::RelationChangeProtection
                                                 @klass.journaled_attribute_names & updates.keys.map(&:to_sym)
                                               elsif updates.is_a?(String)
                                                 @klass.journaled_attribute_names.select do |a|
-                                                  updates.match?(/(^|\A|[ \.\"])#{a}[\z \"$]/)
+                                                  updates.match?(/\b(?<!')#{a}(?!')\b/)
                                                 end
                                               else
                                                 raise "unsupported type '#{updates.class}' for 'updates'"

--- a/lib/journaled/version.rb
+++ b/lib/journaled/version.rb
@@ -1,3 +1,3 @@
 module Journaled
-  VERSION = "2.1.0".freeze
+  VERSION = "2.1.1".freeze
 end

--- a/spec/models/database_change_protection_spec.rb
+++ b/spec/models/database_change_protection_spec.rb
@@ -26,6 +26,7 @@ if Rails::VERSION::MAJOR > 5 || (Rails::VERSION::MAJOR == 5 && Rails::VERSION::M
         it "refuses on journaled columns passed as string" do
           expect { journaled_class.update_all("\"locked_at\" = NULL") }.to raise_error(/aborted by Journaled/)
           expect { journaled_class.update_all("locked_at = null") }.to raise_error(/aborted by Journaled/)
+          expect { journaled_class.update_all("delayed_jobs.locked_at = null") }.to raise_error(/aborted by Journaled/)
           expect { journaled_class.update_all("last_error = 'locked_at'") }.not_to raise_error
         end
 

--- a/spec/models/database_change_protection_spec.rb
+++ b/spec/models/database_change_protection_spec.rb
@@ -19,8 +19,14 @@ if Rails::VERSION::MAJOR > 5 || (Rails::VERSION::MAJOR == 5 && Rails::VERSION::M
 
     describe "the relation" do
       describe "#update_all" do
-        it "refuses on journaled columns" do
+        it "refuses on journaled columns passed as hash" do
           expect { journaled_class.update_all(locked_at: nil) }.to raise_error(/aborted by Journaled/)
+        end
+
+        it "refuses on journaled columns passed as string" do
+          expect { journaled_class.update_all("\"locked_at\" = NULL") }.to raise_error(/aborted by Journaled/)
+          expect { journaled_class.update_all("locked_at = null") }.to raise_error(/aborted by Journaled/)
+          expect { journaled_class.update_all("last_error = 'locked_at'") }.not_to raise_error
         end
 
         it "succeeds on unjournaled columns" do


### PR DESCRIPTION
### Summary

adds support for string updates on relations

it turns out that newer versions of devise use `update_all("\"failed_attempts\" = COALESCE(\"failed_attempts\", 0) + 1")` which breaks the current code's expectation that updates are made with hashes. according to the rails docs, strings and hashes and arrays are allowed. for now i'm only going as far as to support strings and hashes. https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-update_all

this uses a hacky regexp matching strategy that allows word boundary
characters except single quotes because those imply that the contents
are part of a value and not a column name


### Other Information

> If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

> Thanks for contributing to Journaled!

<!-- Please leave the below code review requests in place -->
/domain @Betterment/journaled-owners
/platform @jmileham @coreyja @ceslami @danf1024
