### PR TITLE
Minify the dependency graph

### DIFF
--- a/journaled.gemspec
+++ b/journaled.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib,journaled_schemas}/**/*", "LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "aws-sdk-resources", "< 4"
+  s.add_dependency "aws-sdk-kinesis", "< 2"
   s.add_dependency "delayed_job"
   s.add_dependency "json-schema"
   s.add_dependency "rails", ">= 5.1", "< 7.0"

--- a/lib/journaled.rb
+++ b/lib/journaled.rb
@@ -1,4 +1,4 @@
-require "aws-sdk-resources"
+require "aws-sdk-kinesis"
 require "delayed_job"
 require "json-schema"
 require "request_store"

--- a/lib/journaled/version.rb
+++ b/lib/journaled/version.rb
@@ -1,3 +1,3 @@
 module Journaled
-  VERSION = "2.3.0".freeze
+  VERSION = "2.3.1".freeze
 end


### PR DESCRIPTION
### Summary

This PR cuts the gem's runtime dependency graph _waaaaay_ down, making downstream lockfiles smaller, and potentially reducing the runtime overhead in consuming apps.

Basically, the `aws-sdk-resources` gem is a meta gem that depends on and loads every possible AWS dependency. Of those, Journaled seems only to use `aws-sdk-kinesis` (and the core gems that it already depends on), so I swapped just that gem in.

### Other Information

In total this removes about 850 lines from the gem's own lockfile (not shown below since those are gitignored), which comes from ~270 unique dependencies that we don't need in order for this gem to load and function.

/domain @Betterment/journaled-owners
/platform @jmileham @coreyja @ceslami @danf1024

# Before:

![Screen Shot 2020-04-27 at 11 37 54 PM](https://user-images.githubusercontent.com/83998/80445266-cdcced80-88e1-11ea-8868-2496293ae830.png)

# After:

![Screen Shot 2020-04-27 at 11 39 02 PM](https://user-images.githubusercontent.com/83998/80445272-d32a3800-88e1-11ea-98aa-150feb3e1a1c.png)

