### PR TITLE
Make timeouts configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ Journaling provides a number of different configuation options that can be set i
   This can be used to configure what `priority` the Delayed Jobs are enqueued with. This will be applied to all the Journaled::Devivery jobs that are created by this application.
   Ex: `Journaled.job_priority = 14`
 
+#### `Journaled.http_idle_timeout` (default: 1 second)
+
+  The number of seconds a persistent connection is allowed to sit idle before it should no longer be used.
+
+#### `Journaled.http_open_timeout` (default: 15 seconds)
+
+  The number of seconds before the :http_handler should timeout while trying to open a new HTTP session.
+
+#### `Journaled.http_read_timeout` (default: 60 seconds)
+
+  The number of seconds before the :http_handler should timeout while waiting for a HTTP response.
+
 #### DJ `enqueue` options
 
 Both model-level directives accept additional options to be passed into DelayedJob's `enqueue` method:

--- a/app/models/journaled/delivery.rb
+++ b/app/models/journaled/delivery.rb
@@ -1,4 +1,4 @@
-class Journaled::Delivery
+class Journaled::Delivery # rubocop:disable Betterment/ActiveJobPerformable
   DEFAULT_REGION = 'us-east-1'.freeze
 
   def initialize(serialized_event:, partition_key:, app_name:)
@@ -26,6 +26,9 @@ class Journaled::Delivery
     {
       region: ENV.fetch('AWS_DEFAULT_REGION', DEFAULT_REGION),
       retry_limit: 0,
+      http_idle_timeout: Journaled.http_idle_timeout,
+      http_open_timeout: Journaled.http_open_timeout,
+      http_read_timeout: Journaled.http_read_timeout,
     }.merge(credentials)
   end
 

--- a/lib/journaled.rb
+++ b/lib/journaled.rb
@@ -9,6 +9,9 @@ require 'journaled/enqueue'
 module Journaled
   mattr_accessor :default_app_name
   mattr_accessor(:job_priority) { 20 }
+  mattr_accessor(:http_idle_timeout) { 5 }
+  mattr_accessor(:http_open_timeout) { 15 }
+  mattr_accessor(:http_read_timeout) { 60 }
 
   def development_or_test?
     %w(development test).include?(Rails.env)

--- a/spec/models/journaled/delivery_spec.rb
+++ b/spec/models/journaled/delivery_spec.rb
@@ -185,5 +185,38 @@ RSpec.describe Journaled::Delivery do
         expect(subject.kinesis_client_config).to include(access_key_id: 'key_id', secret_access_key: 'secret')
       end
     end
+
+    it "will set http_idle_timeout by default" do
+      expect(subject.kinesis_client_config).to include(http_idle_timeout: 5)
+    end
+
+    it "will set http_open_timeout by default" do
+      expect(subject.kinesis_client_config).to include(http_open_timeout: 15)
+    end
+
+    it "will set http_read_timeout by default" do
+      expect(subject.kinesis_client_config).to include(http_read_timeout: 60)
+    end
+
+    context "when Journaled.http_idle_timeout is specified" do
+      it "will set http_idle_timeout by specified value" do
+        allow(Journaled).to receive(:http_idle_timeout).and_return(2)
+        expect(subject.kinesis_client_config).to include(http_idle_timeout: 2)
+      end
+    end
+
+    context "when Journaled.http_open_timeout is specified" do
+      it "will set http_open_timeout by specified value" do
+        allow(Journaled).to receive(:http_open_timeout).and_return(2)
+        expect(subject.kinesis_client_config).to include(http_open_timeout: 2)
+      end
+    end
+
+    context "when Journaled.http_read_timeout is specified" do
+      it "will set http_read_timeout by specified value" do
+        allow(Journaled).to receive(:http_read_timeout).and_return(2)
+        expect(subject.kinesis_client_config).to include(http_read_timeout: 2)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Summary

> Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

Current http_open_timeout is set to 15 seconds, which is causing some issues with today's AWS Kinesis outage. Make this value and some other timeout values configurable

### Other Information

> If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

> Thanks for contributing to Journaled!

<!-- Please leave the below code review requests in place -->
/domain @Betterment/journaled-owners
/platform @jmileham @coreyja @ceslami @danf1024
