### PR TITLE
Change default http_open_timeout to 2 seconds (from 15 seconds)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Journaling provides a number of different configuation options that can be set i
 
   The number of seconds a persistent connection is allowed to sit idle before it should no longer be used.
 
-#### `Journaled.http_open_timeout` (default: 15 seconds)
+#### `Journaled.http_open_timeout` (default: 2 seconds)
 
   The number of seconds before the :http_handler should timeout while trying to open a new HTTP session.
 

--- a/lib/journaled.rb
+++ b/lib/journaled.rb
@@ -10,7 +10,7 @@ module Journaled
   mattr_accessor :default_app_name
   mattr_accessor(:job_priority) { 20 }
   mattr_accessor(:http_idle_timeout) { 5 }
-  mattr_accessor(:http_open_timeout) { 15 }
+  mattr_accessor(:http_open_timeout) { 2 }
   mattr_accessor(:http_read_timeout) { 60 }
 
   def development_or_test?

--- a/lib/journaled/version.rb
+++ b/lib/journaled/version.rb
@@ -1,3 +1,3 @@
 module Journaled
-  VERSION = "2.4.0".freeze
+  VERSION = "2.5.0".freeze
 end

--- a/spec/models/journaled/delivery_spec.rb
+++ b/spec/models/journaled/delivery_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe Journaled::Delivery do
     end
 
     it "will set http_open_timeout by default" do
-      expect(subject.kinesis_client_config).to include(http_open_timeout: 15)
+      expect(subject.kinesis_client_config).to include(http_open_timeout: 2)
     end
 
     it "will set http_read_timeout by default" do
@@ -207,8 +207,8 @@ RSpec.describe Journaled::Delivery do
 
     context "when Journaled.http_open_timeout is specified" do
       it "will set http_open_timeout by specified value" do
-        allow(Journaled).to receive(:http_open_timeout).and_return(2)
-        expect(subject.kinesis_client_config).to include(http_open_timeout: 2)
+        allow(Journaled).to receive(:http_open_timeout).and_return(1)
+        expect(subject.kinesis_client_config).to include(http_open_timeout: 1)
       end
     end
 


### PR DESCRIPTION
### Summary

A 15 second timeout proved to be a bit too high when we encountered AWS Kinesis issues a few months back. At Betterment, we've been running internally at a 2 second `http_open_timeout` ever since the incident without any issues. Expressing this lower timeout as the default value.

### Other Information

/domain @Betterment/journaled-owners @RowanMcDonald @smudge 
/platform @jmileham @coreyja @danf1024 @RowanMcDonald @smudge 
