### PR TITLE
Threadsafe "with_transactional_batching" block method

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,6 +682,14 @@ This feature can be disabled conditionally:
 Journaled.transactional_batching_enabled = false
 ```
 
+And can then be enabled via the following block:
+
+```ruby
+Journaled.with_transactional_batching do
+  # your code
+end
+```
+
 Backwards compatibility has been included for background jobs enqueued by
 version 4.0 and above, but **has been dropped for jobs emitted by versions prior
 to 4.0**. (Again, be sure to upgrade only one major version at a time.)

--- a/lib/journaled.rb
+++ b/lib/journaled.rb
@@ -18,6 +18,18 @@ module Journaled
   mattr_accessor(:job_base_class_name) { 'ActiveJob::Base' }
   mattr_accessor(:transactional_batching_enabled) { true }
 
+  def transactional_batching_enabled?
+    super || Thread.current[:journaled_transactional_batching_enabled]
+  end
+
+  def self.with_transactional_batching
+    value_was = Thread.current[:journaled_transactional_batching_enabled]
+    Thread.current[:journaled_transactional_batching_enabled] = true
+    yield
+  ensure
+    Thread.current[:journaled_transactional_batching_enabled] = value_was
+  end
+
   def self.development_or_test?
     %w(development test).include?(Rails.env)
   end

--- a/lib/journaled.rb
+++ b/lib/journaled.rb
@@ -16,10 +16,10 @@ module Journaled
   mattr_accessor(:http_open_timeout) { 2 }
   mattr_accessor(:http_read_timeout) { 60 }
   mattr_accessor(:job_base_class_name) { 'ActiveJob::Base' }
-  mattr_accessor(:transactional_batching_enabled) { true }
+  mattr_writer(:transactional_batching_enabled) { true }
 
-  def transactional_batching_enabled?
-    super || Thread.current[:journaled_transactional_batching_enabled]
+  def self.transactional_batching_enabled?
+    Thread.current[:journaled_transactional_batching_enabled] || @@transactional_batching_enabled
   end
 
   def self.with_transactional_batching

--- a/lib/journaled/audit_log.rb
+++ b/lib/journaled/audit_log.rb
@@ -83,7 +83,7 @@ module Journaled
 
       def dup
         super.tap do |config|
-          config.ignored_columns = ignored_columns.dup
+          config.ignored_columns = ignored_columns.dup # rubocop:disable Rails/IgnoredColumnsAssignment
           config.enqueue_opts = enqueue_opts.dup
         end
       end

--- a/lib/journaled/connection.rb
+++ b/lib/journaled/connection.rb
@@ -2,7 +2,7 @@ module Journaled
   module Connection
     class << self
       def available?
-        Journaled.transactional_batching_enabled && transaction_open?
+        Journaled.transactional_batching_enabled? && transaction_open?
       end
 
       def stage!(event)

--- a/lib/journaled/connection.rb
+++ b/lib/journaled/connection.rb
@@ -6,7 +6,7 @@ module Journaled
       end
 
       def stage!(event)
-        raise TransactionSafetyError, <<~MSG unless transaction_open?
+        raise TransactionSafetyError, <<~MSG unless available?
           Transaction not available! By default, journaled event batching requires an open database transaction.
         MSG
 

--- a/lib/journaled/version.rb
+++ b/lib/journaled/version.rb
@@ -1,3 +1,3 @@
 module Journaled
-  VERSION = "5.2.0".freeze
+  VERSION = "5.3.0".freeze
 end

--- a/spec/lib/journaled/connection_spec.rb
+++ b/spec/lib/journaled/connection_spec.rb
@@ -41,17 +41,17 @@ RSpec.describe Journaled::Connection do
             expect { described_class.stage!(event) }.to raise_error(Journaled::TransactionSafetyError)
           end
         end
-      end
 
-      context 'but thread-local batching is enabled' do
-        around do |example|
-          Journaled.with_transactional_batching { example.run }
-        end
+        context 'but thread-local batching is enabled' do
+          around do |example|
+            Journaled.with_transactional_batching { example.run }
+          end
 
-        it 'returns true, and allows for staging events' do
-          ActiveRecord::Base.transaction do
-            expect(described_class.available?).to be true
-            expect { described_class.stage!(event) }.not_to raise_error
+          it 'returns true, and allows for staging events' do
+            ActiveRecord::Base.transaction do
+              expect(described_class.available?).to be true
+              expect { described_class.stage!(event) }.not_to raise_error
+            end
           end
         end
       end


### PR DESCRIPTION
### Summary

This adds a `Journaled.with_transactional_batching { }` feature that can be used to conditionally enable batching within the current thread, even if the feature is disabled globally.

/domain @Betterment/journaled-owners 
/no-platform
