### PR TITLE
Replace `/domain` & `/platform` in PR template with `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Betterment/journaled-owners

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,3 @@ request, mention that information here. This could include
 benchmarks, or other information.
 
 > Thanks for contributing to Journaled!
-
-<!-- Please leave the below code review requests in place -->
-/domain @Betterment/journaled-owners
-/platform @jmileham @coreyja @ceslami @danf1024


### PR DESCRIPTION
### Summary

This removes `/domain` and `/platform` declarations from the PR template and replaces them with a default CODEOWNERS-driven review request.

/no-platform