### PR TITLE
fix: Journaled::Outbox::Adapter should respect Journaled.enabled?

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    journaled (6.2.3)
+    journaled (6.2.4)
       activejob
       activerecord
       activesupport

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    journaled (6.2.3)
+    journaled (6.2.4)
       activejob
       activerecord
       activesupport

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    journaled (6.2.3)
+    journaled (6.2.4)
       activejob
       activerecord
       activesupport

--- a/lib/journaled/outbox/adapter.rb
+++ b/lib/journaled/outbox/adapter.rb
@@ -21,6 +21,8 @@ module Journaled
       # @param ** [Hash] Additional options (ignored, for interface compatibility)
       # @return [void]
       def self.deliver(events:, **)
+        return unless Journaled.enabled?
+
         check_table_exists!
 
         records = events.map do |event|

--- a/lib/journaled/version.rb
+++ b/lib/journaled/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Journaled
-  VERSION = "6.2.3"
+  VERSION = "6.2.4"
 end

--- a/spec/models/journaled/writer_spec.rb
+++ b/spec/models/journaled/writer_spec.rb
@@ -503,6 +503,7 @@ RSpec.describe Journaled::Writer do
     context 'with Outbox::Adapter' do
       before do
         skip "Outbox tests require PostgreSQL" unless ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+        allow(Journaled).to receive(:enabled?).and_return(true)
       end
 
       around do |example|


### PR DESCRIPTION
### Summary

Prevent adding rows to `journaled_outbox_events` if `Journaled.enabled?` returns false.

/no-platform