### PR TITLE
feat: export a Sorbet RBI declaring the ActiveRecord::Base mixin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    journaled (6.2.8)
+    journaled (6.2.9)
       activejob
       activerecord
       activesupport

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    journaled (6.2.8)
+    journaled (6.2.9)
       activejob
       activerecord
       activesupport

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    journaled (6.2.8)
+    journaled (6.2.9)
       activejob
       activerecord
       activesupport

--- a/journaled.gemspec
+++ b/journaled.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.metadata['rubygems_mfa_required'] = 'true'
 
-  s.files = Dir["{app,config,db,lib,journaled_schemas}/**/*", "LICENSE", "Rakefile", "README.md"]
+  s.files = Dir["{app,config,db,lib,journaled_schemas,rbi}/**/*", "LICENSE", "Rakefile", "README.md"]
 
   s.required_ruby_version = ">= 3.2"
 

--- a/lib/journaled/version.rb
+++ b/lib/journaled/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Journaled
-  VERSION = "6.2.8"
+  VERSION = "6.2.9"
 end

--- a/rbi/journaled.rbi
+++ b/rbi/journaled.rbi
@@ -1,0 +1,13 @@
+# typed: true
+
+# Journaled mixes AuditLog into every Active Record class at boot via
+# `ActiveSupport.on_load(:active_record) { include Journaled::AuditLog }`
+# (lib/journaled/audit_log.rb). Runtime reflection tools attribute that mixin
+# inconsistently depending on load order — under some hosts it lands in the
+# activerecord gem's RBI, under others it is lost entirely — so declare it
+# here. Tapioca merges RBI files a gem exports under rbi/ into the RBI it
+# generates for the gem, which makes `has_audit_log`, `skip_audit_log`, and
+# the blocked-method guards resolve statically in every consuming app.
+class ActiveRecord::Base
+  include Journaled::AuditLog
+end


### PR DESCRIPTION
## Problem

Journaled mixes `AuditLog` into every Active Record class at boot:

```ruby
ActiveSupport.on_load(:active_record) { include Journaled::AuditLog }
```

Runtime reflection tools — specifically `tapioca gem` — attribute that mixin inconsistently depending on the host app's load order. In some apps the `include` lands in the generated **activerecord** RBI, in others it's lost entirely. Apps in the latter group see Sorbet errors like:

```
Method `skip_audit_log` does not exist on `T.class_of(SomeModel)` https://srb.help/7003
```

on every model that calls `skip_audit_log`/`has_audit_log`, and end up hand-writing the same shim:

```ruby
class ActiveRecord::Base
  extend ::Journaled::AuditLog::ClassMethods
end
```

## Fix

Tapioca [merges RBI files a gem exports under `rbi/`](https://github.com/Shopify/tapioca#rbi-files-for-missing-gems--dsls) into the RBI it generates for that gem. This PR ships the one declaration reflection loses:

```ruby
class ActiveRecord::Base
  include Journaled::AuditLog
end
```

That single `include` is sufficient — tapioca's generated RBI for the `Journaled::AuditLog` module already carries `mixes_in_class_methods` for `ClassMethods` and `BlockedClassMethods`, so `has_audit_log`, `skip_audit_log`, and the blocked-method guards (`update_all`, `delete_all`, …) all resolve statically through it. Deliberately minimal: declaring methods the generator already emits would risk merge conflicts at generation time.

Also adds `rbi` to the gemspec `files` glob so the file ships in the built gem.

## Verification

Copied `rbi/journaled.rbi` into an installed copy of journaled 6.2.8 inside a Rails app whose generated journaled RBI lacked the mixin, then:

1. `bin/tapioca gem journaled` → the regenerated `journaled@6.2.8.rbi` now contains `include ::Journaled::AuditLog` in its `ActiveRecord::Base` block
2. deleted the app's hand-written shim
3. `srb tc` → zero `skip_audit_log`/`has_audit_log` errors

The exported file is inert for non-Sorbet consumers (nothing loads `rbi/` at runtime).
