### PR TITLE
feat: add tagged to Journaled::Change

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    journaled (6.3.0)
+    journaled (7.0.0)
       activejob
       activerecord
       activesupport

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Pass `tagged: true` to also include a `tags` field sourced from the current
 journal_changes_to :email, :first_name, :last_name, as: :identity_change, tagged: true
 ```
 
-This is useful for capturing metadata (like an impersonating actor) that isn't
+This is useful for capturing metadata (like a session or visitor ID) that isn't
 itself a column on the model. It defaults to `false` to preserve the existing
 event shape for models that don't opt in.
 
@@ -858,7 +858,7 @@ gem version.
 
 As such, **we always recommend upgrading only one major version at a time.**
 
-### Upgrading from 6.2.9
+### Upgrading from 6.x
 
 `journal_changes_to` now accepts a `tagged:` option (default `false`). This is
 opt-in at the Ruby level, so no application code needs to change to upgrade.

--- a/README.md
+++ b/README.md
@@ -858,6 +858,19 @@ gem version.
 
 As such, **we always recommend upgrading only one major version at a time.**
 
+### Upgrading from 6.2.9
+
+`journal_changes_to` now accepts a `tagged:` option (default `false`). This is
+opt-in at the Ruby level, so no application code needs to change to upgrade.
+
+However, the `journaled/change` JSON schema (`journaled_schemas/journaled/change.json`)
+now permits an optional `tags` property on every `Journaled::Change` event,
+regardless of whether any particular model opts in. If you (or a downstream
+consumer of this stream) validate `Journaled::Change` payloads against a copy
+of this schema, or against your own stricter schema, that schema needs to
+tolerate a `tags` field being present, since any model in the producing app
+could begin sending it independently of your consumer.
+
 ### Upgrading from 4.3.0
 
 Versions of Journaled prior to 5.0 would enqueue events one at a time, but 5.0

--- a/README.md
+++ b/README.md
@@ -359,6 +359,17 @@ record is created or destroyed, an event will be sent to Kinesis with the follow
   * `actor` - a string (usually a rails global_id) representing who
     performed the action.
 
+Pass `tagged: true` to also include a `tags` field sourced from the current
+[tagged event](#tagged-events) context (e.g. `Journaled.tag!`/`Journaled.tagged`):
+
+```ruby
+journal_changes_to :email, :first_name, :last_name, as: :identity_change, tagged: true
+```
+
+This is useful for capturing metadata (like an impersonating actor) that isn't
+itself a column on the model. It defaults to `false` to preserve the existing
+event shape for models that don't opt in.
+
 Callback-bypassing database methods like `update_all`, `delete_all`,
 `update_columns` and `delete` are intercepted and will require an
 additional `force: true` argument if they would interfere with change

--- a/app/models/concerns/journaled/changes.rb
+++ b/app/models/concerns/journaled/changes.rb
@@ -56,14 +56,18 @@ module Journaled::Changes
   end
 
   class_methods do
-    def journal_changes_to(*attribute_names, as:, enqueue_with: {})
+    def journal_changes_to(*attribute_names, as:, enqueue_with: {}, tagged: false)
       if attribute_names.empty? || attribute_names.any? { |n| !n.is_a?(Symbol) }
         raise "one or more symbol attribute_name arguments is required"
       end
 
       raise "as: must be a symbol" unless as.is_a?(Symbol)
 
-      _journaled_change_definitions << Journaled::ChangeDefinition.new(attribute_names: attribute_names, logical_operation: as)
+      _journaled_change_definitions << Journaled::ChangeDefinition.new(
+        attribute_names: attribute_names,
+        logical_operation: as,
+        tagged: tagged,
+      )
       journaled_attribute_names.concat(attribute_names)
       journaled_enqueue_opts.merge!(enqueue_with)
     end

--- a/app/models/journaled/change.rb
+++ b/app/models/journaled/change.rb
@@ -26,7 +26,8 @@ class Journaled::Change
                  changes:,
                  journaled_stream_name:,
                  journaled_enqueue_opts:,
-                 actor:)
+                 actor:,
+                 tagged: false)
     @table_name = table_name
     @record_id = record_id
     @database_operation = database_operation
@@ -35,5 +36,18 @@ class Journaled::Change
     @journaled_stream_name = journaled_stream_name
     @journaled_enqueue_opts = journaled_enqueue_opts
     @actor = actor
+    @tagged = tagged
+  end
+
+  def tagged?
+    @tagged
+  end
+
+  def tags
+    Journaled::Current.tags
+  end
+
+  def journaled_attributes
+    tagged? ? super.merge(tags:) : super
   end
 end

--- a/app/models/journaled/change_definition.rb
+++ b/app/models/journaled/change_definition.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class Journaled::ChangeDefinition
-  attr_reader :attribute_names, :logical_operation
+  attr_reader :attribute_names, :logical_operation, :tagged
 
-  def initialize(attribute_names:, logical_operation:)
+  def initialize(attribute_names:, logical_operation:, tagged: false)
     @attribute_names = attribute_names.map(&:to_s)
     @logical_operation = logical_operation
+    @tagged = tagged
     @validated = false
   end
 

--- a/app/models/journaled/change_writer.rb
+++ b/app/models/journaled/change_writer.rb
@@ -3,7 +3,7 @@
 class Journaled::ChangeWriter
   attr_reader :model, :change_definition
 
-  delegate :attribute_names, :logical_operation, to: :change_definition
+  delegate :attribute_names, :logical_operation, :tagged, to: :change_definition
 
   def initialize(model:, change_definition:)
     @model = model
@@ -33,6 +33,7 @@ class Journaled::ChangeWriter
       journaled_stream_name: journaled_stream_name,
       journaled_enqueue_opts: model.journaled_enqueue_opts,
       actor: actor_uri,
+      tagged: tagged,
     )
   end
 

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    journaled (6.3.0)
+    journaled (7.0.0)
       activejob
       activerecord
       activesupport

--- a/journaled_schemas/journaled/change.json
+++ b/journaled_schemas/journaled/change.json
@@ -41,6 +41,10 @@
     },
     "actor": {
       "type": ["string", null]
+    },
+    "tags": {
+      "type": "object",
+      "additionalProperties": true
     }
   }
 }

--- a/lib/journaled/version.rb
+++ b/lib/journaled/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Journaled
-  VERSION = "6.3.0"
+  VERSION = "7.0.0"
 end

--- a/spec/models/journaled/change_spec.rb
+++ b/spec/models/journaled/change_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Journaled::Change do
+  subject(:change) do
+    described_class.new(
+      table_name: 'widgets',
+      record_id: '1',
+      database_operation: 'update',
+      logical_operation: :widget_change,
+      changes: '{}',
+      journaled_stream_name: nil,
+      journaled_enqueue_opts: {},
+      actor: 'gid://app/User/1',
+      tagged:,
+    )
+  end
+
+  context 'when tagged: false (the default)' do
+    let(:tagged) { false }
+
+    it 'omits :tags from the journaled payload' do
+      expect(change.journaled_attributes.keys).not_to include(:tags)
+    end
+  end
+
+  context 'when tagged: true' do
+    let(:tagged) { true }
+
+    around do |example|
+      Journaled.tagged(impersonator: 'gid://app/Advisor/2') { example.run }
+    end
+
+    it 'includes the current Journaled tags in the journaled payload' do
+      expect(change.journaled_attributes[:tags]).to eq(impersonator: 'gid://app/Advisor/2')
+    end
+  end
+
+  context 'when a tagged instance and an untagged instance coexist' do
+    subject(:untagged_change) do
+      described_class.new(
+        table_name: 'widgets',
+        record_id: '1',
+        database_operation: 'update',
+        logical_operation: :widget_change,
+        changes: '{}',
+        journaled_stream_name: nil,
+        journaled_enqueue_opts: {},
+        actor: 'gid://app/User/1',
+        tagged: false,
+      )
+    end
+
+    let(:tagged_change) do
+      described_class.new(
+        table_name: 'widgets',
+        record_id: '2',
+        database_operation: 'update',
+        logical_operation: :widget_change,
+        changes: '{}',
+        journaled_stream_name: nil,
+        journaled_enqueue_opts: {},
+        actor: 'gid://app/User/2',
+        tagged: true,
+      )
+    end
+
+    it 'includes :tags only in the tagged instance\'s payload' do
+      tagged_change
+
+      expect(untagged_change.journaled_attributes.keys).not_to include(:tags)
+    end
+  end
+end

--- a/spec/models/journaled/change_writer_spec.rb
+++ b/spec/models/journaled/change_writer_spec.rb
@@ -140,6 +140,24 @@ RSpec.describe Journaled::ChangeWriter do
       expect(subject.journaled_change_for("update", {}).logical_operation).to eq("identity_change")
     end
 
+    it "defaults to untagged" do
+      expect(subject.journaled_change_for("update", {})).not_to be_tagged
+    end
+
+    context "when the change_definition is tagged" do
+      let(:change_definition) do
+        Journaled::ChangeDefinition.new(
+          attribute_names: %i(name rank serial_number),
+          logical_operation: "identity_change",
+          tagged: true,
+        )
+      end
+
+      it "builds a tagged Journaled::Change" do
+        expect(subject.journaled_change_for("update", {})).to be_tagged
+      end
+    end
+
     it "doesn't set journaled_stream_name if model class doesn't respond to it" do
       expect(subject.journaled_change_for("update", {}).journaled_stream_name).to be_nil
     end


### PR DESCRIPTION
Add support for the gem's existing "tagged" mechanism to `Journaled::Change`, so apps that use `Journaled.tag!`/`Journaled.tagged` to attach per-request context (e.g.  actor metadata, request ID, span, job ID, etc) can now see that context on change events.
