### PR TITLE
fix(journaled): jprecich / bump missing journaled version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    journaled (7.0.0)
+    journaled (7.1.0)
       activejob
       activerecord
       activesupport
@@ -85,7 +85,6 @@ GEM
       bigdecimal
       rexml
     crass (1.0.7)
-    date (3.4.1)
     diff-lcs (1.5.1)
     drb (2.2.3)
     erb (6.0.7)
@@ -231,7 +230,6 @@ GEM
       spring (>= 0.9.1)
     sqlite3 (2.9.5-arm64-darwin)
     sqlite3 (2.9.5-x86_64-linux-gnu)
-    stringio (3.1.2)
     thor (1.5.0)
     timecop (0.9.10)
     timeout (0.4.3)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    journaled (7.0.0)
+    journaled (7.1.0)
       activejob
       activerecord
       activesupport

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    journaled (7.0.0)
+    journaled (7.1.0)
       activejob
       activerecord
       activesupport

--- a/lib/journaled/version.rb
+++ b/lib/journaled/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Journaled
-  VERSION = "7.0.0"
+  VERSION = "7.1.0"
 end


### PR DESCRIPTION
### Summary

There was a Rails 8.1 version bump in boundaries [PR](https://github.com/Betterment/journaled/pull/83) that got merged recently but I forgot to add a new version so it could be released
